### PR TITLE
Improve docker-compose file and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,29 @@
 See the documentation to find how to use this boilerplate:
 
 https://docs.activitypods.org/tutorials/create-your-first-social-app/
+
+## Make Commands for Managing the Activitypods Provider
+
+### For Development
+
+`make start` Starts the activitypods provider using a docker-compose file. This includes the activitypods backend and frontend server, the fuseki db, mailcatcher, redis, and arena.
+
+`make stop` Stops and removes all containers for the activitypods provider.
+
+`make config` Prints the config with the `.env`-file-provided environment variables filled.
+
+`make logs-activitypods` Prints the activitypods provider logs.
+
+`attach-activitypods` Attaches to the [moleculer](https://moleculer.services/) repl of the activitypods backend.
+
+### For Production
+
+`build-prod` Builds the activitypods provider images for production. In addition to the dev images, this includes a traefik reverse proxy.
+
+`start-prod` Starts the activitypods provider containers for production.
+
+`stop-prod` Stops and removes running activitypods provider containers.
+
+`config-prod` Prints the config with the `.env`-file-provided environment variables filled.
+
+`attach-backend-prod` Attaches to the [moleculer](https://moleculer.services/) repl of the activitypods backend.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,9 +1,8 @@
 services:
   fuseki:
     image: semapps/jena-fuseki-webacl
-    container_name: fuseki
     volumes:
-      - ./data/fuseki:/fuseki
+      - ./data/fuseki:/fuseki:z
     ports:
       - "3030:3030"
     expose:
@@ -13,49 +12,45 @@ services:
 
   activitypods-backend:
     image: activitypods/backend
-    container_name: activitypods-backend
     depends_on:
       - fuseki
       - redis
     restart: always
     expose:
-      - '3000'
+      - "3000"
     volumes:
-      - ./data/backend/logs:/app/backend/logs
-      - ./data/backend/jwt:/app/backend/jwt
-      - ./data/backend/uploads:/app/backend/uploads
+      - ./data/backend/logs:/app/backend/logs:z
+      - ./data/backend/jwt:/app/backend/jwt:z
+      - ./data/backend/uploads:/app/backend/uploads:z
     environment:
       SEMAPPS_JENA_PASSWORD: admin
       SEMAPPS_DEFAULT_LOCALE: en
       SEMAPPS_MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:?You must set it in the .env.local file}
     # Allow the Pod backend to access the app backend
     # See https://docs.docker.com/network/drivers/host/
-    network_mode: "host" 
+    network_mode: "host"
 
   activitypods-frontend:
     image: activitypods/frontend
-    container_name: activitypods-frontend
     depends_on:
       - activitypods-backend
     restart: always
     ports:
       - "5000:5000"
     expose:
-      - '5000'
+      - "5000"
     environment:
       REACT_APP_CONFIG_URL: "http://localhost:3000/.well-known/config.js"
 
   mailcatcher:
     image: dockage/mailcatcher:0.7.1
-    container_name: mailcatcher
     ports:
-      - '1080:1080'
-      - '1025:1025'
+      - "1080:1080"
+      - "1025:1025"
     restart: on-failure
 
   redis:
     image: redis
-    container_name: redis
     expose:
       - "6379"
     ports:
@@ -66,10 +61,9 @@ services:
 
   arena:
     image: activitypods/arena
-    container_name: arena
     restart: always
     volumes:
-      - ./arena-dev.json:/opt/arena/src/server/config/index.json
+      - ./arena-dev.json:/opt/arena/src/server/config/index.json:z
     depends_on:
       - redis
     expose:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,6 @@
 services:
   traefik:
     image: traefik:v2.3
-    container_name: traefik
     command:
       - "--api.insecure=true"
       - "--providers.docker=true"
@@ -19,14 +18,13 @@ services:
       - "443:443"
       - "8080:8080"
     volumes:
-      - ./data/letsencrypt:/letsencrypt
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./data/letsencrypt:/letsencrypt:z
+      - /var/run/docker.sock:/var/run/docker.sock:ro:z
 
   fuseki:
     image: semapps/jena-fuseki-webacl
-    container_name: fuseki
     volumes:
-      - ./data/fuseki:/fuseki
+      - ./data/fuseki:/fuseki:z
     ports:
       - "3030:3030"
     expose:
@@ -38,7 +36,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.frontend
-    container_name: app-frontend
     restart: always
     expose:
       - "4000"
@@ -57,14 +54,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.backend
-    container_name: app-backend
     depends_on:
       - fuseki
       - redis
     volumes:
-      - ./data/backend/logs:/app/backend/logs
-      - ./data/backend/jwt:/app/backend/jwt
-      - ./data/backend/uploads:/app/backend/uploads
+      - ./data/backend/logs:/app/backend/logs:z
+      - ./data/backend/jwt:/app/backend/jwt:z
+      - ./data/backend/uploads:/app/backend/uploads:z
     expose:
       - "3000"
     labels:
@@ -80,7 +76,6 @@ services:
 
   redis:
     image: redis
-    container_name: redis
     expose:
       - "6379"
     volumes:
@@ -89,10 +84,9 @@ services:
 
   arena:
     image: activitypods/arena
-    container_name: arena
     restart: always
     volumes:
-      - ./arena-prod.json:/opt/arena/src/server/config/index.json
+      - ./arena-prod.json:/opt/arena/src/server/config/index.json:z
     depends_on:
       - redis
     expose:


### PR DESCRIPTION
- add `:z` file to docker-compose volume mounts where missing
- remove `container_name`s from docker-compose files to prevent conflicts with other containers of the same name
- add description of make commands in the readme that start/manage the provider